### PR TITLE
Fix typo in sql-database config; enable 27.x

### DIFF
--- a/src/sql-presto.el
+++ b/src/sql-presto.el
@@ -6,10 +6,6 @@
 ;; Keywords: sql presto database
 ;; Package-Requires: ((emacs "24.4"))
 
-
-;;; Commentary:
-;; $$COMMENTARY$$
-
 ;;; Code:
 (require 'sql)
 
@@ -60,16 +56,16 @@ The buffer with name BUFFER will be used or created."
 ;; then, it complains that sql-presto-comint isn't a valid function, so WTF. Stick to
 ;; 26.3 for now.
 (sql-add-product 'presto "Presto"
-                 :free-software t
-                 :list-all "SHOW TABLES;"
-                 :list-table "DESCRIBE %s;"
-                 :prompt-regexp "^[^>]*> "
-                 :prompt-cont-regexp "^[ ]+-> "
-                 :sqli-comint-func 'sql-presto-comint
-                 :font-lock 'sql-mode-ansi-font-lock-keywords
-                 :sqli-login sql-presto-login-params
-                 :sqli-program 'sql-presto-program
-                 :sqli-options 'sql-presto-options)
+                 '(:free-software t
+                   :list-all "SHOW TABLES;"
+                   :list-table "DESCRIBE %s;"
+                   :prompt-regexp "^[^>]*> "
+                   :prompt-cont-regexp "^[ ]+-> "
+                   :sqli-comint-func sql-presto-comint
+                   :font-lock sql-mode-ansi-font-lock-keywords
+                   :sqli-login sql-presto-login-params
+                   :sqli-program sql-presto-program
+                   :sqli-options sql-presto-options))
 
 ;; It's kind of annoying to get a sql-mode buffer to connect to a SQLi buffer,
 ;; so this automates a lot of it.

--- a/src/sql-presto.el
+++ b/src/sql-presto.el
@@ -42,7 +42,7 @@ the SQLi buffer to be named."
   (let ((params (append (unless (string= "" sql-server)
                           `("--server" ,sql-server))
                         (unless (string= "" sql-database)
-                          `("--catalog" sql-database))
+                          `("--catalog" ,sql-database))
                         options)))
     ;; See: https://github.com/prestodb/presto/issues/2907
     (setenv "PRESTO_PAGER" "cat")

--- a/src/sql-presto.el
+++ b/src/sql-presto.el
@@ -68,5 +68,23 @@ The buffer with name BUFFER will be used or created."
                  :sqli-program 'sql-presto-program
                  :sqli-options 'sql-presto-options)
 
+;; It's kind of annoying to get a sql-mode buffer to connect to a SQLi buffer,
+;; so this automates a lot of it.
+;;
+;; this answer helps me understand how to link a sql buffer to a presto SQLi
+;; buffer: https://stackoverflow.com/a/14322667 
+(defun sql-prestofy-buffer ()
+  "Make a generic sql-mode buffer into a connected presto buffer."
+  (interactive)
+  (sql-set-product "presto")
+  (sql-set-sqli-buffer))
+
+(defun sql-presto-scratch ()
+  "Open a scratch buffer that connects to a presto instance."
+  (interactive)
+  (switch-to-buffer "*sql-scratch*")
+  (sql-mode)
+  (sql-prestofy-buffer))
+
 (provide 'sql-presto)
 ;;; sql-presto.el ends here

--- a/src/sql-presto.el
+++ b/src/sql-presto.el
@@ -56,6 +56,9 @@ The buffer with name BUFFER will be used or created."
   (interactive "P")
   (sql-product-interactive 'presto buffer))
 
+;; in emacs 27.1, the plist of options needs to be wrapped, like '(:foo "bar"). But even
+;; then, it complains that sql-presto-comint isn't a valid function, so WTF. Stick to
+;; 26.3 for now.
 (sql-add-product 'presto "Presto"
                  :free-software t
                  :list-all "SHOW TABLES;"
@@ -72,7 +75,7 @@ The buffer with name BUFFER will be used or created."
 ;; so this automates a lot of it.
 ;;
 ;; this answer helps me understand how to link a sql buffer to a presto SQLi
-;; buffer: https://stackoverflow.com/a/14322667 
+;; buffer: https://stackoverflow.com/a/14322667
 (defun sql-prestofy-buffer ()
   "Make a generic sql-mode buffer into a connected presto buffer."
   (interactive)

--- a/src/sql-presto.el
+++ b/src/sql-presto.el
@@ -52,9 +52,6 @@ The buffer with name BUFFER will be used or created."
   (interactive "P")
   (sql-product-interactive 'presto buffer))
 
-;; in emacs 27.1, the plist of options needs to be wrapped, like '(:foo "bar"). But even
-;; then, it complains that sql-presto-comint isn't a valid function, so WTF. Stick to
-;; 26.3 for now.
 (sql-add-product 'presto "Presto"
                  '(:free-software t
                    :list-all "SHOW TABLES;"

--- a/src/sql-presto.el
+++ b/src/sql-presto.el
@@ -83,7 +83,8 @@ The buffer with name BUFFER will be used or created."
   (interactive)
   (switch-to-buffer "*sql-scratch*")
   (sql-mode)
-  (sql-prestofy-buffer))
+  (sql-prestofy-buffer)
+  (display-buffer "*sql-scratch*"))
 
 (provide 'sql-presto)
 ;;; sql-presto.el ends here


### PR DESCRIPTION
Fix a typo which prevents the user from specifying a default catalog.

Also, make syntax changes which allows this to play nice with Emacs 27.x.